### PR TITLE
Removing an error on the installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ commands on a platform that uses apt-get:
 
 ```
     sudo apt-add-repository "ppa:agronick/relay"
-    sudo apt-get update`
+    sudo apt-get update
     sudo apt-get install relay
 ```    
 


### PR DESCRIPTION
There was "update`" instead of "update" (the error was the` character).

Btw, it seems nice! I will install it when I switch to eOS ;)
